### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/DATAPACK.md
+++ b/DATAPACK.md
@@ -14,8 +14,8 @@ ordering target selectors:
 * https://www.reddit.com/r/MinecraftCommands/comments/nw90u4/does_using_predicates_in_place_of_complicated/h18lr5u/
 raycast: https://www.reddit.com/r/MinecraftCommands/comments/9n1ghh/raycasting_in_1131/e7kxv2o/
 check if player is looking toward/away: https://www.reddit.com/r/MinecraftCommands/comments/akjyh5/help_any_way_to_execute_if_a_player_is_looking_at/ef5jehw/
-item nbt structure: https://minecraft.fandom.com/wiki/Player.dat_format#Item_structure
-json text components: https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Component_resolution
+item nbt structure: https://minecraft.wiki/w/Player.dat_format#Item_structure
+json text components: https://minecraft.wiki/w/Raw_JSON_text_format#Component_resolution
 
 ### Version History
 
@@ -43,7 +43,7 @@ charge time
 
 ## Advancement Triggers
 
-https://minecraft.fandom.com/wiki/Advancement/JSON_format#List_of_triggers
+https://minecraft.wiki/w/Advancement/JSON_format#List_of_triggers
 
 ### Generic
 
@@ -98,7 +98,7 @@ https://minecraft.fandom.com/wiki/Advancement/JSON_format#List_of_triggers
 
 ## Predicate Conditions
 
-https://minecraft.fandom.com/wiki/Predicate
+https://minecraft.wiki/w/Predicate
 
     alternative - Joins conditions from parameter terms with "or".
     block_state_property - Check properties of a block state.
@@ -120,7 +120,7 @@ https://minecraft.fandom.com/wiki/Predicate
 
 ## Scoreboard Objective Criteria
 
-https://minecraft.fandom.com/wiki/Scoreboard#Criteria
+https://minecraft.wiki/w/Scoreboard#Criteria
 
 ### Simple Criteria
 
@@ -143,7 +143,7 @@ https://minecraft.fandom.com/wiki/Scoreboard#Criteria
 
 ### Compound Statistic Criteria
 
-https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names
+https://minecraft.wiki/w/Statistics#Statistic_types_and_names
 
     minecraft.mined:<block_mined>
     minecraft.broken:<item_broken>
@@ -154,7 +154,7 @@ https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names
     minecraft.killed:<entity_that_player_killed>
     minecraft.killed_by:<entity_that_killed_player>
 
-https://minecraft.fandom.com/wiki/Statistics#List_of_custom_statistic_names
+https://minecraft.wiki/w/Statistics#List_of_custom_statistic_names
 
     minecraft.custom:minecraft.animals_bred
     minecraft.custom:minecraft.clean_armor

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -55,7 +55,7 @@ image::https://i.imgur.com/WLFKdEM.png[Painting Overhaul]
 * https://en.wikipedia.org/wiki/Xu_Beihong[Galloping Horse]
 * https://en.wikipedia.org/wiki/American_Gothic[Testificate Gothic]
 * https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog[Farlander Above the Sea of Fog]
-* https://minecraft.gamepedia.com/Painting[Burning Skull]
+* https://minecraft.wiki/w/Painting[Burning Skull]
 * https://www.twoinchbrush.com/painting/night-light[Night Light]
 
 4x2 Paintings:
@@ -679,7 +679,7 @@ assets/minecraft/sounds.json
 == Tag Data Packs
 
 These are simple yet powerful commandless data packs that work by modifying
-https://minecraft.fandom.com/wiki/Tag[tags]
+https://minecraft.wiki/w/Tag[tags]
 in the vanilla game.
 They shouldn't add any lag to your game.
 
@@ -2643,7 +2643,7 @@ they gain Levitation II and Slowness II for 10 seconds,
 and saddling a pig while wearing the chestplate makes it hover.
 
 **Relic of Rainbows**: When a
-https://minecraft.fandom.com/wiki/Sheep#Easter_eggs[rainbow sheep]
+https://minecraft.wiki/w/Sheep#Easter_eggs[rainbow sheep]
 dies from an explosion,
 it drops pink dye with Myth of Chromatic Blasts,
 a custom enchantment that can be applied to a crossbow
@@ -3764,7 +3764,7 @@ they should be ordered this way from _bottom to top_,
 NOT top to bottom as one might intuitively expect.
 
 To reorder datapacks, use the
-https://minecraft.fandom.com/wiki/Commands/datapack[`/datapack`]
+https://minecraft.wiki/w/Commands/datapack[`/datapack`]
 command.
 
 == Language Support
@@ -3774,7 +3774,7 @@ Renaming in languages other than `en_us` (US English)
 is done on a best effort basis.
 Below is a summary of resource packs that support other language codes.
 You can use
-https://minecraft.fandom.com/wiki/Language#Languages[the Language page]
+https://minecraft.wiki/w/Language#Languages[the Language page]
 on the Minecraft Wiki to look up a language code.
 
 .Summary of language support

--- a/README.asciidoc.sempl
+++ b/README.asciidoc.sempl
@@ -55,7 +55,7 @@ image::https://i.imgur.com/WLFKdEM.png[Painting Overhaul]
 * https://en.wikipedia.org/wiki/Xu_Beihong[Galloping Horse]
 * https://en.wikipedia.org/wiki/American_Gothic[Testificate Gothic]
 * https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog[Farlander Above the Sea of Fog]
-* https://minecraft.gamepedia.com/Painting[Burning Skull]
+* https://minecraft.wiki/w/Painting[Burning Skull]
 * https://www.twoinchbrush.com/painting/night-light[Night Light]
 
 4x2 Paintings:
@@ -275,7 +275,7 @@ Discreet Meow makes cats meow less often.
 == Tag Data Packs
 
 These are simple yet powerful commandless data packs that work by modifying
-https://minecraft.fandom.com/wiki/Tag[tags]
+https://minecraft.wiki/w/Tag[tags]
 in the vanilla game.
 They shouldn't add any lag to your game.
 
@@ -1192,7 +1192,7 @@ they gain Levitation II and Slowness II for 10 seconds,
 and saddling a pig while wearing the chestplate makes it hover.
 
 **Relic of Rainbows**: When a
-https://minecraft.fandom.com/wiki/Sheep#Easter_eggs[rainbow sheep]
+https://minecraft.wiki/w/Sheep#Easter_eggs[rainbow sheep]
 dies from an explosion,
 it drops pink dye with Myth of Chromatic Blasts,
 a custom enchantment that can be applied to a crossbow
@@ -1956,7 +1956,7 @@ they should be ordered this way from _bottom to top_,
 NOT top to bottom as one might intuitively expect.
 
 To reorder datapacks, use the
-https://minecraft.fandom.com/wiki/Commands/datapack[`/datapack`]
+https://minecraft.wiki/w/Commands/datapack[`/datapack`]
 command.
 
 == Language Support
@@ -1966,7 +1966,7 @@ Renaming in languages other than `en_us` (US English)
 is done on a best effort basis.
 Below is a summary of resource packs that support other language codes.
 You can use
-https://minecraft.fandom.com/wiki/Language#Languages[the Language page]
+https://minecraft.wiki/w/Language#Languages[the Language page]
 on the Minecraft Wiki to look up a language code.
 
 .Summary of language support

--- a/buce-data/portal/nether/enter.function.mcfunction
+++ b/buce-data/portal/nether/enter.function.mcfunction
@@ -22,7 +22,7 @@ execute in minecraft:the_nether store result score #buce.ntp var run locate stru
 # up to 2 chunks diagonally away in nether,
 # or 9 chunks diagonally away in overworld
 #
-# https://minecraft.fandom.com/wiki/Tutorials/Nether_portals#How_portals_work
+# https://minecraft.wiki/w/Tutorials/Nether_portals#How_portals_work
 execute if score #buce.owp var matches 204.. if score #buce.ntp var matches 46.. run fill ~23 ~23 ~1 ~-23 ~-23 ~-1 minecraft:air replace minecraft:nether_portal
 execute if score #buce.owp var matches 204.. if score #buce.ntp var matches 46.. run fill ~1 ~23 ~23 ~-1 ~-23 ~-23 minecraft:air replace minecraft:nether_portal
 

--- a/data/minecraft/tags/blocks/mineable/exclude.json
+++ b/data/minecraft/tags/blocks/mineable/exclude.json
@@ -12,7 +12,7 @@
     "Blocks I've deliberately not added because of gameplay or verisimilitude",
 
     "Blocks that instantly break with no tool as documented on",
-    "row of https://minecraft.fandom.com/wiki/Instant_mining#Without_commands",
+    "row of https://minecraft.wiki/w/Instant_mining#Without_commands",
 
     "Blocks that instantly break that aren't documented in the link above"
   ],


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.